### PR TITLE
Update Vite config to exclude `react/jsx-runtime` in order to support both React 18 and 19

### DIFF
--- a/packages/pdf-annotator-react/vite.config.js
+++ b/packages/pdf-annotator-react/vite.config.js
@@ -25,9 +25,12 @@ export default defineConfig(({ command, mode }) => ({
       fileName: (format) => `react-pdf-annotator.${format}.js`
     },
     rollupOptions: {
-      external: [...Object.keys(packageJson.peerDependencies)],
+      external: [...Object.keys(packageJson.peerDependencies), 'react/jsx-runtime'],
       output: {
-        assetFileNames: 'react-pdf-annotator.[ext]'
+        assetFileNames: 'react-pdf-annotator.[ext]',
+        globals: {
+          'react/jsx-runtime': 'ReactJsxRuntime',
+        }
       }
     },
     sourcemap: true,


### PR DESCRIPTION
## In this PR

Per https://stackoverflow.com/a/79350215, support both React 18 and 19 by excluding `react/jsx-runtime` from the Vite config.